### PR TITLE
https na API Criaenvio.

### DIFF
--- a/Criaenvio_loader.php
+++ b/Criaenvio_loader.php
@@ -1,6 +1,6 @@
 <?php
 
-define('NN_URL_API', 'http://api.criaenvio.com/');
+define('NN_URL_API', 'https://api.criaenvio.com/');
 define('NN_VERSAO', 'v1');
 
 spl_autoload_register(


### PR DESCRIPTION
Adicionando https na URL da API Criaenvio.
Testado e Funcionando.
Impossível adicionar redirecionamento automático para o domínio da API pois resulta em erro.